### PR TITLE
Differentiate CC3200 from CC3200-EMT

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,15 +1,15 @@
-CC3200-LAUNCHXL.name=CC3200-LAUNCHXL (80MHz)
-CC3200-LAUNCHXL.upload.maximum_size=262144
-CC3200-LAUNCHXL.build.mcu=cortex-m4
-CC3200-LAUNCHXL.build.f_cpu=80000000L
-CC3200-LAUNCHXL.build.core=cc3200emt
-CC3200-LAUNCHXL.build.variant=CC3200_LAUNCHXL
-CC3200-LAUNCHXL.build.ldscript=ti/runtime/wiring/cc3200/linker.cmd
-CC3200-LAUNCHXL.build.board=CC3200_LAUNCHXL
-CC3200-LAUNCHXL.build.mcu=cortex-m4
-CC3200-LAUNCHXL.upload.tool=cc3200prog
-CC3200-LAUNCHXL.upload.protocol=cc3200prog
-#CC3200-LAUNCHXL.upload.maximum_data_size=32768
+CC3200_LAUNCHXL_EMT.name=CC3200-LAUNCHXL EMT (80MHz)
+CC3200_LAUNCHXL_EMT.upload.maximum_size=262144
+CC3200_LAUNCHXL_EMT.build.mcu=cortex-m4
+CC3200_LAUNCHXL_EMT.build.f_cpu=80000000L
+CC3200_LAUNCHXL_EMT.build.core=cc3200emt
+CC3200_LAUNCHXL_EMT.build.variant=CC3200_LAUNCHXL
+CC3200_LAUNCHXL_EMT.build.ldscript=ti/runtime/wiring/cc3200/linker.cmd
+CC3200_LAUNCHXL_EMT.build.board=CC3200_LAUNCHXL
+CC3200_LAUNCHXL_EMT.build.mcu=cortex-m4
+CC3200_LAUNCHXL_EMT.upload.tool=cc3200prog
+CC3200_LAUNCHXL_EMT.upload.protocol=cc3200prog
+#CC3200_LAUNCHXL_EMT.upload.maximum_data_size=32768
 ##############################################################
 
 #CC3200-RBL.name=RedBearLab CC3200 (80MHz)


### PR DESCRIPTION
* Display `CC3200-LAUNCHXL (80MHz) EMT` on the Tools > Board menu
* Differentiate `CC3200-LAUNCHXL` from `CC3200_LAUNCHXL_EMT`
* Use compatible characters, `_` instead of `-`.