### PR TITLE
Stream: make _timeout field and related methods protected

### DIFF
--- a/cores/cc3200emt/ti/runtime/wiring/Stream.h
+++ b/cores/cc3200emt/ti/runtime/wiring/Stream.h
@@ -37,7 +37,7 @@ readBytesBetween( pre_string, terminator, buffer, length)
 
 class Stream : public Print
 {
-    private:
+    protected:
         unsigned long _timeout;      // number of milliseconds to wait for the next char before aborting timed read
         unsigned long _startMillis;  // used for timeout measurement
         int timedRead();    // private method to read stream with timeout


### PR DESCRIPTION
This makes the Stream class implementation more aligned with the original Arduino Stream class, and allows using other libraries such as ArduinoHttpClient.
As a side note, also in the Energia core for CC3200 these fields and method are declared protected.